### PR TITLE
Removing erroneous dizque_instance causing add_fillers to fail

### DIFF
--- a/dizqueTV/models/fillers.py
+++ b/dizqueTV/models/fillers.py
@@ -178,7 +178,7 @@ class FillerList(BaseAPIObject):
         filler_list_data = self._data
 
         fillers = self._dizque_instance.expand_custom_show_items(
-            programs=fillers, dizque_instance=self
+            programs=fillers
         )
 
         for filler in fillers:


### PR DESCRIPTION
Within Fillers Model, add_fillers had a call to expand_custom_show_items which included programs and dizque_instance, but expand_custom_show_items only accepts programs - dizque_instance not accepted here (see https://dizquetv.readthedocs.io/en/latest/documentation.html#dizqueTV.dizquetv.API.expand_custom_show_items )

--
Traceback (most recent call last):
  File "/opt/bobflix/playlist_to_filler.py", line 93, in <module>
    fillerlist.add_fillers(fillers=to_add)
  File "/usr/local/lib/python3.8/dist-packages/dizqueTV/decorators.py", line 19, in inner
    return func(obj, **kwargs)
  File "/usr/local/lib/python3.8/dist-packages/dizqueTV/models/fillers.py", line 180, in add_fillers
    fillers = self._dizque_instance.expand_custom_show_items(
TypeError: expand_custom_show_items() got an unexpected keyword argument 'dizque_instance'